### PR TITLE
Fixed error in increment value

### DIFF
--- a/moola/algorithms/bfgs.py
+++ b/moola/algorithms/bfgs.py
@@ -205,7 +205,7 @@ class BFGS(OptimisationAlgorithm):
             self.update({'iteration' : it,
                          'control'   : xk,
                          'grad_norm' : dJ_xk.primal_norm(),
-                         'delta_J'   : oldJ-J,
+                         'delta_J'   : abs(oldJ-J),
                          'objective' : J,
                          'lbfgs'     : Hk })
             self.record_progress()

--- a/moola/algorithms/hybrid_cg.py
+++ b/moola/algorithms/hybrid_cg.py
@@ -179,7 +179,7 @@ class HybridCG(OptimisationAlgorithm):
             self.update({'iteration' : i,
                          'control'   : x,
                          'grad_norm' : r.primal_norm(),
-                         'delta_J'   : oldJ-J,
+                         'delta_J'   : abs(oldJ-J),
                          'objective' : J,
                          'lbfgs'     : B })
             self.record_progress()

--- a/moola/algorithms/newton_cg.py
+++ b/moola/algorithms/newton_cg.py
@@ -174,7 +174,7 @@ class NewtonCG(OptimisationAlgorithm):
             self.update({'iteration' : i,
                          'control'   : x,
                          'grad_norm' : r.primal_norm(),
-                         'delta_J'   : oldJ-J,
+                         'delta_J'   : abs(oldJ-J),
                          'objective' : J,
                          'lbfgs'     : B })
             self.record_progress()

--- a/moola/algorithms/nonlinear_cg.py
+++ b/moola/algorithms/nonlinear_cg.py
@@ -119,7 +119,7 @@ class NonLinearCG(OptimisationAlgorithm):
             J, old_J = obj(x), J
             #update
             self.update(iteration = it, control = x, grad_norm = sqrt(grad_norm2),
-                        objective = J, delta_J = old_J - J)
+                        objective = J, delta_J = abs(old_J - J))
             self.record_progress()
 
         # Print the reason for convergence

--- a/moola/algorithms/steepest_descent.py
+++ b/moola/algorithms/steepest_descent.py
@@ -97,6 +97,7 @@ class SteepestDescent(OptimisationAlgorithm):
             self.update({"control"   : m,
                          "iteration" : it,
                          "grad_norm" : grad.norm(),
+                         "delta_J"   : abs(j - j_prev),
                          "objective" : j})
             self.record_progress()
         return self.data


### PR DESCRIPTION
There was a bug in the computation of the increment delta_J, computed as 

delta_J = oldJ - J

meaning that the error could be negative, and that was always smaller than any given (positive) tolerance.